### PR TITLE
Update geth node version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM ethereum/client-go:v1.9.12
+FROM ethereum/client-go:v1.9.24
 
-ENV GETH_OPTIONS "-dev -dev.period 0 -rpc -rpcport 7545 --rpcaddr 0.0.0.0 --wsaddr 0.0.0.0  --miner.gastarget 0x2014103 -keystore geth -password '' --allow-insecure-unlock --rpcapi eth,web3,personal" 
+RUN touch /geth-empty-password
+
+ENV GETH_OPTIONS "--dev --dev.period 0 --rpc --rpcport 7545 --rpcaddr 0.0.0.0 --wsaddr 0.0.0.0  --miner.gastarget 0x2014103 --keystore geth --allow-insecure-unlock --rpcapi eth,web3,personal --password /geth-empty-password"
 
 EXPOSE 7545
 


### PR DESCRIPTION
In order to run the new geth node version inside CI we need to update the dev image version.

The updated image can be found here: 
https://hub.docker.com/layers/derain/ethereum-dev-node/0.0.3/images/sha256-e1805450e2bb0aa40657e11394064f00238f8fa95e57d57d798b58d55cdcd79f?context=explore

To pull a new image version run: `docker pull derain/ethereum-dev-node:0.0.3`